### PR TITLE
Parse the tweet's source out of the <a> tag

### DIFF
--- a/docker/import_user.py
+++ b/docker/import_user.py
@@ -381,7 +381,7 @@ def import_tweets(screen_name):
 
                 MERGE (user)-[:POSTS]->(tweet)
 
-                MERGE (source:Source {name:t.source})
+                MERGE (source:Source {name:REPLACE(SPLIT(t.source, ">")[1], "</a", "")})
                 MERGE (tweet)-[:USING]->(source)
 
                 FOREACH (h IN e.hashtags |


### PR DESCRIPTION
This used to render nicely in the Neo4j browser as a hyperlink, but that is no longer the case.

Before: `<a href="http://twitter.com/download/android" rel="nofollow">Twitter for Android</a>`
After: `Twitter for Android`
